### PR TITLE
Use `uv` to speed up env setup in CI

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,5 +31,5 @@ runs:
       - name: Install requirements
         shell: bash
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements/dev.txt
+          python -m pip install uv
+          uv pip install -r requirements/dev.txt

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ runs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check out tags
         shell: bash
@@ -20,7 +20,7 @@ runs:
           python-version: "3.11"
 
       - name: Cache deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip

--- a/action.yml
+++ b/action.yml
@@ -15,21 +15,23 @@ runs:
           git fetch --prune --unshallow --tags
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Cache pip
+      - name: Cache deps
         uses: actions/cache@v3
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements/dev.txt') }}
+          path: |
+            ~/.cache/pip
+            ~/.cache/uv
+          key: ${{ runner.os }}-deps-${{ hashFiles('requirements/dev.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-
+            ${{ runner.os }}-deps-
             ${{ runner.os }}-
 
       - name: Install requirements
         shell: bash
         run: |
           python -m pip install uv
-          uv pip install -r requirements/dev.txt
+          uv pip install --system -r requirements/dev.txt


### PR DESCRIPTION
## Summary

[`uv`](https://github.com/astral-sh/uv) is a `pip` "drop-in" replacement, written in rust and runs super fast.

- Uses `uv` to install python deps
- Upgrades actions to fix warnings about deprecated Node.js 16