### PR TITLE
PN-2859: add configurable python-version input (default 3.11)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,12 @@ name: Setup test environment
 
 description: Setup test environment to use in other actions
 
+inputs:
+  python-version:
+    description: "Python version passed to actions/setup-python"
+    required: false
+    default: "3.11"
+
 runs:
     using: "composite"
 
@@ -17,7 +23,7 @@ runs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ inputs.python-version }}
 
       - name: Cache deps
         uses: actions/cache@v4


### PR DESCRIPTION
## What
Adds a `python-version` input to the composite action (default `"3.11"`) and feeds it to `actions/setup-python` instead of the hardcoded value.

## Why
Part of PN-2859 (base-platform → Python 3.13). This action is consumed as `@master`, so hardcoding `3.13` would switch **every** consumer's CI at once and break branches that haven't migrated yet (e.g. code still importing `distutils`, removed in 3.12+).

## Backward compatibility
Callers that don't pass `with: python-version` keep getting `"3.11"` — no change for any existing consumer. Safe to merge ahead of / independently from the base-platform work.

## Rollout
1. Merge this first (no behavior change for existing callers).
2. base-platform's PN-2859 branch opts in at its `setup-test-environment@master` call sites with `with: python-version: "3.13"`.
3. As PN-2859 merges forward, the opt-in travels with the workflow files; other branches migrate when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
